### PR TITLE
Add scope to README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you can spare some time in helping maintain this addon, please let us know in
 ## Installation
 
 ```sh
-$ ember install ember-stripe-elements
+$ ember install @adopted-ember-addons/ember-stripe-elements
 ```
 
 ## Compatibility


### PR DESCRIPTION
Current install instructions may resolve to older `ember-stripe-elements` (@code-corps/ember-stripe-elements).

Instructions should include scope of this addon `@adopted-ember-addons/ember-stripe-elements` for disambiguation.