### PR TITLE
Additional testing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ When using the Stripe mock in tests you will likely need to override the mock's 
 ```js
 this.owner.lookup('service:stripev3').createToken = () => ({ token: { id: 'token' } });
 ```
+### Testing and Simulating User Input
+
+When a {{stripe-element}} is instantiated and in the DOM, the underlying `stripeElement` is available via the `stripev3` service. Calling `stripeService.getActiveElements()` will return an array of those native stripeElements. 
+
+This is primarily useful in testing.  Stripe renders an iframe which is mostly inaccessible in a test environment, making simulating user input impossible.
+
+You can fill this gap by making the `stripeElement` emit compatible events, which is a reasonable simulation of the results when in a test context. 
+
+This add-on includes some handy utilities for this purpose that can be imported from stripe-mock. 
+
+```js
+import { stripeEventUtils } from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
+
+stripeEventUtils.triggerReady(stripeElement)
+stripeEventUtils.triggerBlur(stripeElement)
+stripeEventUtils.triggerFocus(stripeElement)
+stripeEventUtils.triggerIncomplete(stripeElement)
+stripeEventUtils.triggerComplete(stripeElement)
+stripeEventUtils.triggerError(stripeElement, additionalArgs)
+stripeEventUtils.triggerChange(stripeElement, additionalArgs)
+```
+
+Both `triggerError` and `triggerChange` accept a second argument that can be used to override the default event attributes provided by this addon.
+
+Note: these will not actually change the content of the Stripe UI, they simply force the stripeElement to emit events that are being listened for. WARNING: These utilities rely on undocumented methods, so this may break in the future. This is only intended for use in a test environment. The events are also not exhaustive, but cover the core user flows.
+
+```js 
+import { stripeEventUtils } from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
+
+  test('user enters valid data', function(assert) {
+
+    //...some code rendering a {{stripe element}}
+
+    const [stripeElement] = stripeService.getActiveElements();
+    stripeEventUtils.triggerComplete(stripeElement);
+    ...
+  });
+```
 
 ### Lazy loading
 

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -90,7 +90,7 @@ export default Component.extend({
       }
 
       let [{ complete, error: stripeError }] = args;
-      this.change(stripeElement, ...args);
+      this._invokeAction('onChange', stripeElement, ...args)
 
       if (complete) {
         this._invokeAction('onComplete', stripeElement)

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -70,7 +70,7 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     const stripeElement = get(this, 'stripeElement');
-    this.stripev3.addStripeElement(stripeElement);
+    this.stripev3.removeStripeElement(stripeElement);
     stripeElement.unmount();
   },
 

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -40,6 +40,7 @@ export default Component.extend({
 
     // Make the element available to the component
     set(this, 'stripeElement', stripeElement);
+    this.stripev3.addStripeElement(stripeElement);
 
     // Set the event listeners
     this.setEventListeners();
@@ -51,6 +52,8 @@ export default Component.extend({
     let autofocus = get(this, 'autofocus');
     let stripeElement = get(this, 'stripeElement');
     let iframe = this.element.querySelector('iframe');
+    this._invokeAction('onLoad', stripeElement);
+
     if (autofocus && iframe) {
       iframe.onload = () => {
         stripeElement.focus();
@@ -66,7 +69,9 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    get(this, 'stripeElement').unmount();
+    const stripeElement = get(this, 'stripeElement');
+    this.stripev3.addStripeElement(stripeElement);
+    stripeElement.unmount();
   },
 
   setEventListeners() {

--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -95,7 +95,7 @@ export default Service.extend({
   removeStripeElement(stripeElement){
     this._stripeElements.removeObject(stripeElement);
   },
-  activeElements(){
+  getActiveElements(){
     return [...this._stripeElements];
   }
 });

--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -5,6 +5,7 @@ import { readOnly } from '@ember/object/computed';
 import { resolve } from 'rsvp';
 import loadScript from '@adopted-ember-addons/ember-stripe-elements/utils/load-script';
 import EmberError from '@ember/error';
+import { A } from '@ember/array';
 
 // As listed at https://stripe.com/docs/stripe-js/reference#the-stripe-object
 const STRIPE_FUNCTIONS = [
@@ -35,13 +36,14 @@ export default Service.extend({
   mock: readOnly('config.mock'),
   publishableKey: null,
   stripeOptions: null,
-
+  
   init() {
     this._super(...arguments);
     this.set('publishableKey', this.get('config.publishableKey'));
     this.set('stripeOptions', this.get('config.stripeOptions'));
 
     let lazyLoad = this.get('lazyLoad');
+    this.set('_stripeElements', A());
 
     if (!lazyLoad) {
       this.configure();
@@ -86,5 +88,14 @@ export default Service.extend({
 
       this.set('didConfigure', true);
     }
+  },
+  addStripeElement(stripeElement){
+    this._stripeElements.pushObject(stripeElement);
+  },
+  removeStripeElement(stripeElement){
+    this._stripeElements.removeObject(stripeElement);
+  },
+  activeElements(){
+    return [...this._stripeElements];
   }
 });

--- a/addon/utils/stripe-mock.js
+++ b/addon/utils/stripe-mock.js
@@ -13,6 +13,7 @@ StripeMock.prototype.elements = function() {
     }
   };
 }
+
 StripeMock.prototype.confirmCardPayment = function() {};
 StripeMock.prototype.createToken = function() {};
 StripeMock.prototype.createSource = function() {};
@@ -28,5 +29,50 @@ StripeMock.prototype.handleCardSetup = function() {};
 StripeMock.prototype.confirmCardSetup = function() {};
 StripeMock.prototype.retrieveSetupIntent = function() {};
 StripeMock.prototype.confirmSetupIntent = function() {};
+
+const cardArgs = {
+  elementType: "card"
+}
+
+const baseArgs = {
+  ...cardArgs,
+  "error": undefined,
+  "value": {
+    "postalCode": ""
+  },
+  "empty": true,
+  "complete": false,
+  "brand": "unknown"
+}
+
+const stripeError = {
+  message: "Your card number is invalid.",
+  type: "validation_error",
+  code: "invalid_number"
+}
+
+const argsError = {
+   ...baseArgs,
+   error: stripeError,
+   "brand": "visa",
+   "value": {
+    "postalCode": "12345"
+  }
+}
+
+const argsComplete = {
+   ...baseArgs,
+   "complete":true,
+}
+
+export const stripeEventUtils = {
+  triggerReady     : function(stripeElement) { stripeElement._emitEvent('ready'), cardArgs},
+  triggerBlur      : function(stripeElement) { stripeElement._emitEvent('blur', cardArgs)},
+  triggerFocus     : function(stripeElement) { stripeElement._emitEvent('focus', cardArgs)},
+  triggerIncomplete: function(stripeElement) { stripeElement._emitEvent('change', baseArgs)},
+  triggerError     : function(stripeElement, userArgs = {}) { stripeElement._emitEvent('change', {...argsError, ...userArgs})},
+  triggerComplete  : function(stripeElement) { stripeElement._emitEvent('change', argsComplete)},
+  triggerChange    : function(stripeElement, userArgs = {}) { stripeElement._emitEvent('change', {...baseArgs, ...userArgs})}
+}
 
 export default StripeMock;


### PR DESCRIPTION
We have had trouble testing a full user flow because you can't enter values into the Stripe Element programatically. 

This change provides some utilities to be able to simulate the whole experience. 

Also, fixes an issue with `onChange`