### PR TITLE
Refactor service to native class

### DIFF
--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -1,103 +1,347 @@
-/* eslint-disable ember/no-get */
 /* global Stripe */
 import Service from '@ember/service';
-import { getProperties, setProperties } from '@ember/object';
-import { readOnly } from '@ember/object/computed';
+import { getOwner } from '@ember/application';
 import { resolve } from 'rsvp';
 import loadScript from '@adopted-ember-addons/ember-stripe-elements/utils/load-script';
 import EmberError from '@ember/error';
 import { A } from '@ember/array';
+import { assert } from '@ember/debug';
 
-// As listed at https://stripe.com/docs/stripe-js/reference#the-stripe-object
-const STRIPE_FUNCTIONS = [
-  'elements',
-  'confirmCardPayment',
-  'createToken',
-  'createSource',
-  'createPaymentMethod',
-  'retrieveSource',
-  'paymentRequest',
-  'redirectToCheckout',
-  'retrievePaymentIntent',
-  'handleCardPayment',
-  'handleCardAction',
-  'confirmPaymentIntent',
-  'handleCardSetup',
-  'confirmCardSetup',
-  'retrieveSetupIntent',
-  'confirmSetupIntent'
-];
+export default class StripeService extends Service {
+  _config = null;
+  _didLoad = false;
+  _stripe = null;
+  _elements = A();
 
-// eslint-disable-next-line ember/no-classic-classes
-export default Service.extend({
-  config: null,
-  didConfigure: false,
-  didLoad: false,
+  constructor() {
+    super(...arguments);
+    const config = getOwner(this).resolveRegistration('config:environment') || {};
+    this._config = config.stripe || {};
 
-  lazyLoad: readOnly('config.lazyLoad'),
-  mock: readOnly('config.mock'),
-  publishableKey: null,
-  stripeOptions: null,
-  
-  init() {
-    this._super(...arguments);
-    this.set('publishableKey', this.get('config.publishableKey'));
-    this.set('stripeOptions', this.get('config.stripeOptions'));
-
-    let lazyLoad = this.get('lazyLoad');
-    this.set('_stripeElements', A());
-
-    if (!lazyLoad) {
+    if (!this.lazyLoad) {
       this.configure();
     }
-  },
+  }
+
+  get lazyLoad() {
+    return Boolean(this._config.lazyLoad);
+  }
+
+  get mock() {
+    return Boolean(this._config.mock);
+  }
+
+  get stripeOptions() {
+    return this._config.stripeOptions || {};
+  }
+
+  set stripeOptions(value) {
+    this._config.stripeOptions = value;
+  }
+
+  get publishableKey() {
+    return this._config.publishableKey;
+  }
+
+  set publishableKey(key) {
+    this._config.publishableKey = key;
+  }
+
+  get instance() {
+    assert('Stripe must be loaded.', Boolean(this._stripe));
+    return this._stripe;
+  }
 
   load(publishableKey = null, stripeOptions = null) {
     if (publishableKey) {
-      this.set('publishableKey', publishableKey);
+      this.publishableKey = publishableKey;
     }
 
     if (stripeOptions) {
-      this.set('stripeOptions', stripeOptions);
+      this.stripeOptions = stripeOptions;
     }
 
-    let lazyLoad = this.get('lazyLoad');
-    let mock = this.get('mock');
-    let shouldLoad = lazyLoad && !mock
-
+    let { lazyLoad, mock } = this;
+    let shouldLoad = lazyLoad && !mock;
     let doLoad = shouldLoad ? loadScript("https://js.stripe.com/v3/") : resolve();
 
     return doLoad.then(() => {
       this.configure();
-      this.set('didLoad', true);
+      this._didLoad = true;
     });
-  },
+  }
 
   configure() {
-    let didConfigure = this.get('didConfigure');
-
-    if (!didConfigure) {
-      let publishableKey = this.get('publishableKey');
-      let stripeOptions = this.get('stripeOptions');
+    if (!this._stripe) {
+      let { publishableKey, stripeOptions } = this;
 
       if (!publishableKey) {
         throw new EmberError("stripev3: Missing Stripe key, please set `ENV.stripe.publishableKey` in config.environment.js");
       }
 
-      let stripe = new Stripe(publishableKey, stripeOptions);
-      let functions = getProperties(stripe, STRIPE_FUNCTIONS);
-      setProperties(this, functions);
-
-      this.set('didConfigure', true);
+      this._stripe = new Stripe(publishableKey, stripeOptions);
     }
-  },
-  addStripeElement(stripeElement){
-    this._stripeElements.pushObject(stripeElement);
-  },
-  removeStripeElement(stripeElement){
-    this._stripeElements.removeObject(stripeElement);
-  },
-  getActiveElements(){
-    return [...this._stripeElements];
   }
-});
+
+  addStripeElement(element) {
+    this._elements.pushObject(element);
+  }
+
+  removeStripeElement(element) {
+    this._elements.removeObject(element);
+  }
+
+  getActiveElements() {
+    return [...this._elements];
+  }
+
+  /**
+   * @see https://stripe.com/docs/js/elements_object/create
+   */
+  elements() {
+    return this.instance.elements(...arguments);
+  }
+
+  /**
+   * @see https://stripe.com/docs/js/checkout/redirect_to_checkout
+   */
+  redirectToCheckout() {
+    return this.instance.redirectToCheckout(...arguments);
+  }
+
+  /**
+   * @see https://stripe.com/docs/js/payment_intents/confirm_card_payment
+   */
+  confirmCardPayment() {
+    return this.instance.confirmCardPayment(...arguments);
+  }
+
+  /**
+   * @see https://stripe.com/docs/js/payment_intents/confirm_alipay_payment
+   */
+  confirmAlipayPayment() {
+    return this.instance.confirmAlipayPayment(...arguments);
+  }
+
+  /**
+   * @see https://stripe.com/docs/js/payment_intents/confirm_au_becs_debit_payment
+   */
+   confirmAuBecsDebitPayment() {
+     return this.instance.confirmAuBecsDebitPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_bancontact_payment
+    */
+   confirmBancontactPayment() {
+     return this.instance.confirmBancontactPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_eps_payment
+    */
+   confirmEpsPayment() {
+     return this.instance.confirmEpsPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_fpx_payment
+    */
+   confirmFpxPayment() {
+     return this.instance.confirmFpxPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_giropay_payment
+    */
+   confirmGiropayPayment() {
+     return this.instance.confirmGiropayPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_grabpay_payment
+    */
+   confirmGrabPayPayment() {
+     return this.instance.confirmGrabPayPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_ideal_payment
+    */
+   confirmIdealPayment() {
+     return this.instance.confirmIdealPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_oxxo_payment
+    */
+   confirmOxxoPayment() {
+     return this.instance.confirmOxxoPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_p24_payment
+    */
+   confirmP24Payment() {
+     return this.instance.confirmP24Payment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_sepa_debit_payment
+    */
+   confirmSepaDebitPayment() {
+     return this.instance.confirmSepaDebitPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/confirm_sofort_payment
+    */
+   confirmSofortPayment() {
+     return this.instance.confirmSofortPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/handle_card_action
+    */
+   handleCardAction() {
+     return this.instance.handleCardAction(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_intents/retrieve_payment_intent
+    */
+   retrievePaymentIntent() {
+     return this.instance.retrievePaymentIntent(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_card_setup
+    */
+   confirmCardSetup() {
+     return this.instance.confirmCardSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_au_becs_debit_setup
+    */
+   confirmAuBecsDebitSetup() {
+     return this.instance.confirmAuBecsDebitSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_bacs_debit_setup
+    */
+   confirmBacsDebitSetup() {
+     return this.instance.confirmBacsDebitSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_bancontact_setup
+    */
+   confirmBancontactSetup() {
+     return this.instance.confirmBancontactSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_ideal_setup
+    */
+   confirmIdealSetup() {
+     return this.instance.confirmIdealSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_sepa_debit_setup
+    */
+   confirmSepaDebitSetup() {
+     return this.instance.confirmSepaDebitSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/confirm_sofort_setup
+    */
+   confirmSofortSetup() {
+     return this.instance.confirmSofortSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/setup_intents/retrieve_setup_intent
+    */
+   retrieveSetupIntent() {
+     return this.instance.retrieveSetupIntent(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_methods/create_payment_method
+    */
+   createPaymentMethod() {
+     return this.instance.createPaymentMethod(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/payment_request/create
+    */
+   paymentRequest() {
+     return this.instance.paymentRequest(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/tokens_sources/create_token
+    */
+   createToken() {
+     return this.instance.createToken(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/tokens_sources/create_source
+    */
+   createSource() {
+     return this.instance.createSource(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/tokens_sources/retrieve_source
+    */
+   retrieveSource() {
+     return this.instance.retrieveSource(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/deprecated/handle_card_payment_element
+    * @deprecated
+    */
+   handleCardPayment() {
+     return this.instance.handleCardPayment(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/deprecated/confirm_payment_intent_element
+    * @deprecated
+    */
+   confirmPaymentIntent() {
+     return this.instance.confirmPaymentIntent(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/deprecated/handle_card_setup_element
+    * @deprecated
+    */
+   handleCardSetup() {
+     return this.instance.handleCardSetup(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/deprecated/confirm_setup_intent_element
+    * @deprecated
+    */
+   confirmSetupIntent() {
+     return this.instance.confirmSetupIntent(...arguments);
+   }
+
+   /**
+    * @see https://stripe.com/docs/js/deprecated/handle_fpx_payment
+    * @deprecated
+    */
+   handleFpxPayment() {
+     return this.instance.handleFpxPayment(...arguments);
+   }
+}

--- a/addon/utils/stripe-mock.js
+++ b/addon/utils/stripe-mock.js
@@ -1,34 +1,59 @@
-let StripeMock = function(publishableKey) {
-  this.publishableKey = publishableKey;
-}
+class StripeMock {
+  publishableKey;
+  options;
 
-StripeMock.prototype.elements = function() {
-  return {
-    create: function() {
-      return {
-        mount: function() {},
-        on: function() {},
-        unmount: function() {}
+  constructor(publishableKey, options) {
+    this.publishableKey = publishableKey;
+    this.options = options;
+  }
+
+  elements() {
+    return {
+      create() {
+        return {
+          mount() {},
+          on() {},
+          unmount() {},
+        };
       }
-    }
-  };
-}
+    };
+  }
 
-StripeMock.prototype.confirmCardPayment = function() {};
-StripeMock.prototype.createToken = function() {};
-StripeMock.prototype.createSource = function() {};
-StripeMock.prototype.createPaymentMethod = function() {};
-StripeMock.prototype.retrieveSource = function() {};
-StripeMock.prototype.paymentRequest = function() {};
-StripeMock.prototype.redirectToCheckout = function() {};
-StripeMock.prototype.retrievePaymentIntent = function() {};
-StripeMock.prototype.handleCardPayment = function() {};
-StripeMock.prototype.handleCardAction = function() {};
-StripeMock.prototype.confirmPaymentIntent = function() {};
-StripeMock.prototype.handleCardSetup = function() {};
-StripeMock.prototype.confirmCardSetup = function() {};
-StripeMock.prototype.retrieveSetupIntent = function() {};
-StripeMock.prototype.confirmSetupIntent = function() {};
+  redirectToCheckout() {}
+  confirmCardPayment() {}
+  confirmAlipayPayment() {}
+  confirmAuBecsDebitPayment() {}
+  confirmBancontactPayment() {}
+  confirmEpsPayment() {}
+  confirmFpxPayment() {}
+  confirmGiropayPayment() {}
+  confirmGrabPayPayment() {}
+  confirmIdealPayment() {}
+  confirmOxxoPayment() {}
+  confirmP24Payment() {}
+  confirmSepaDebitPayment() {}
+  confirmSofortPayment() {}
+  handleCardAction() {}
+  retrievePaymentIntent() {}
+  confirmCardSetup() {}
+  confirmAuBecsDebitSetup() {}
+  confirmBacsDebitSetup() {}
+  confirmBancontactSetup() {}
+  confirmIdealSetup() {}
+  confirmSepaDebitSetup() {}
+  confirmSofortSetup() {}
+  retrieveSetupIntent() {}
+  createPaymentMethod() {}
+  paymentRequest() {}
+  createToken() {}
+  createSource() {}
+  retrieveSource() {}
+  handleCardPayment() {}
+  confirmPaymentIntent() {}
+  handleCardSetup() {}
+  confirmSetupIntent() {}
+  handleFpxPayment() {}
+}
 
 const cardArgs = {
   elementType: "card"

--- a/app/initializers/ember-stripe-elements.js
+++ b/app/initializers/ember-stripe-elements.js
@@ -2,11 +2,7 @@ import config from '../config/environment';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
 
 export function initialize() {
-  const application = arguments[1] || arguments[0];
   let stripeConfig = config.stripe || {};
-
-  application.register('config:stripe', stripeConfig, { instantiate: false });
-  application.inject('service:stripev3', 'config', 'config:stripe');
 
   if (typeof FastBoot !== 'undefined' || stripeConfig.mock) {
     window.Stripe = StripeMock;

--- a/tests/integration/components/stripe-card-cvc-test.js
+++ b/tests/integration/components/stripe-card-cvc-test.js
@@ -3,26 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render, find, clearRender } from '@ember/test-helpers';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
-import StripeService from 'dummy/services/stripev3';
 
 module('Integration | Component | stripe-card-cvc', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
-
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders', async function (assert) {

--- a/tests/integration/components/stripe-card-expiry-test.js
+++ b/tests/integration/components/stripe-card-expiry-test.js
@@ -3,27 +3,15 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render, find, clearRender } from '@ember/test-helpers';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
-import StripeService from 'dummy/services/stripev3';
 
 module('Integration | Component | stripe-card-expiry', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-      stripeOptions: env.stripe.stripeOptions,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
 
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders', async function(assert) {

--- a/tests/integration/components/stripe-card-number-test.js
+++ b/tests/integration/components/stripe-card-number-test.js
@@ -3,27 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render, find, clearRender } from '@ember/test-helpers';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
-import StripeService from 'dummy/services/stripev3';
 
 module('Integration | Component | stripe card number', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-      stripeOptions: env.stripe.stripeOptions,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
-
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders', async function(assert) {

--- a/tests/integration/components/stripe-card-test.js
+++ b/tests/integration/components/stripe-card-test.js
@@ -3,27 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render, find, clearRender } from '@ember/test-helpers';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
-import StripeService from 'dummy/services/stripev3';
 
 module('Integration | Component | stripe-card', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-      stripeOptions: env.stripe.stripeOptions,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
-
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders', async function(assert) {

--- a/tests/integration/components/stripe-elements-test.js
+++ b/tests/integration/components/stripe-elements-test.js
@@ -3,27 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find, clearRender } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import StripeService from 'dummy/services/stripev3';
-import env from 'dummy/config/environment';
 
 module('Integration | Component | stripe-elements', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-      stripeOptions: env.stripe.stripeOptions,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
-
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders single-line element', async function (assert) {

--- a/tests/integration/components/stripe-postal-code-test.js
+++ b/tests/integration/components/stripe-postal-code-test.js
@@ -3,27 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render, find, clearRender } from '@ember/test-helpers';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
-import StripeService from 'dummy/services/stripev3';
 
 module('Integration | Component | stripe-postal-code', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    const config = {
-      mock: true,
-      publishableKey: env.stripe.publishableKey,
-      stripeOptions: env.stripe.stripeOptions,
-    };
-
-    this.owner.register(
-      'service:stripev3',
-      StripeService.create({ config }),
-      { instantiate: false }
-    );
-
     this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe.configure();
   });
 
   test('it renders', async function(assert) {

--- a/tests/unit/services/stripev3-test.js
+++ b/tests/unit/services/stripev3-test.js
@@ -2,269 +2,633 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/utils/stripe-mock';
-import env from 'dummy/config/environment';
 
 module('Unit | Service | stripev3', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-    this.subject = this.owner.factoryFor('service:stripev3').create({
-      config: {
-        mock: true,
-        publishableKey: env.stripe.publishableKey,
-        stripeOptions: env.stripe.stripeOptions,
-      }
-    });
+    this.subject = this.owner.lookup('service:stripev3');
   });
 
-  test('makes Stripe.elements available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.elements', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let stub = sinon.stub(this.subject.instance, 'elements');
+    stub.returns(expected);
 
-    let elements = sinon.stub(service, 'elements').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let actual = this.subject.elements();
 
-    elements(mockOptions);
-    elements.restore();
+    assert.ok(stub.calledOnce);
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.confirmCardPayment available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.redirectToCheckout', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let options = { foo: 'bar' };
 
-    let confirmCardPayment = sinon.stub(service, 'confirmCardPayment').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'redirectToCheckout');
+    stub.returns(expected);
 
-    confirmCardPayment(mockOptions);
-    confirmCardPayment.restore();
+    let actual = this.subject.redirectToCheckout(options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.createToken available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmCardPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let createToken = sinon.stub(service, 'createToken').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmCardPayment');
+    stub.returns(expected);
 
-    createToken(mockOptions);
-    createToken.restore();
+    let actual = this.subject.confirmCardPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.createSource available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmAlipayPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let createSource = sinon.stub(service, 'createSource').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmAlipayPayment');
+    stub.returns(expected);
 
-    createSource(mockOptions);
-    createSource.restore();
+    let actual = this.subject.confirmAlipayPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.createPaymentMethod available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmAuBecsDebitPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let createPaymentMethod = sinon.stub(service, 'createPaymentMethod').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmAuBecsDebitPayment');
+    stub.returns(expected);
 
-    createPaymentMethod(mockOptions);
-    createPaymentMethod.restore();
+    let actual = this.subject.confirmAuBecsDebitPayment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.retrieveSource available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmBancontactPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let retrieveSource = sinon.stub(service, 'retrieveSource').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmBancontactPayment');
+    stub.returns(expected);
 
-    retrieveSource(mockOptions);
-    retrieveSource.restore();
+    let actual = this.subject.confirmBancontactPayment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.paymentRequest available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmEpsPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let paymentRequest = sinon.stub(service, 'paymentRequest').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmEpsPayment');
+    stub.returns(expected);
 
-    paymentRequest(mockOptions);
-    paymentRequest.restore();
+    let actual = this.subject.confirmEpsPayment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.redirectToCheckout available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmFpxPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let redirectToCheckout = sinon.stub(service, 'redirectToCheckout').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmFpxPayment');
+    stub.returns(expected);
 
-    redirectToCheckout(mockOptions);
-    redirectToCheckout.restore();
+    let actual = this.subject.confirmFpxPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.retrievePaymentIntent available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmGiropayPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let retrievePaymentIntent = sinon.stub(service, 'retrievePaymentIntent').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmGiropayPayment');
+    stub.returns(expected);
 
-    retrievePaymentIntent(mockOptions);
-    retrievePaymentIntent.restore();
+    let actual = this.subject.confirmGiropayPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.handleCardPayment available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmGrabPayPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let handleCardPayment = sinon.stub(service, 'handleCardPayment').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmGrabPayPayment');
+    stub.returns(expected);
 
-    handleCardPayment(mockOptions);
-    handleCardPayment.restore();
+    let actual = this.subject.confirmGrabPayPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.handleCardAction available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmIdealPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let handleCardAction = sinon.stub(service, 'handleCardAction').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmIdealPayment');
+    stub.returns(expected);
 
-    handleCardAction(mockOptions);
-    handleCardAction.restore();
+    let actual = this.subject.confirmIdealPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.confirmPaymentIntent available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmOxxoPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
 
-    let confirmPaymentIntent = sinon.stub(service, 'confirmPaymentIntent').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmOxxoPayment');
+    stub.returns(expected);
 
-    confirmPaymentIntent(mockOptions);
-    confirmPaymentIntent.restore();
+    let actual = this.subject.confirmOxxoPayment(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.handleCardSetup available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmP24Payment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let handleCardSetup = sinon.stub(service, 'handleCardSetup').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmP24Payment');
+    stub.returns(expected);
 
-    handleCardSetup(mockOptions);
-    handleCardSetup.restore();
+    let actual = this.subject.confirmP24Payment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.confirmCardSetup available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmSepaDebitPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let confirmCardSetup = sinon.stub(service, 'confirmCardSetup').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmSepaDebitPayment');
+    stub.returns(expected);
 
-    confirmCardSetup(mockOptions);
-    confirmCardSetup.restore();
+    let actual = this.subject.confirmSepaDebitPayment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.retrieveSetupIntent available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.confirmSofortPayment', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
 
-    let retrieveSetupIntent = sinon.stub(service, 'retrieveSetupIntent').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'confirmSofortPayment');
+    stub.returns(expected);
 
-    retrieveSetupIntent(mockOptions);
-    retrieveSetupIntent.restore();
+    let actual = this.subject.confirmSofortPayment(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
   });
 
-  test('makes Stripe.confirmSetupIntent available on the service', function(assert) {
-    assert.expect(1);
+  test('it proxies stripe.handleCardAction', function (assert) {
+    this.subject.configure();
 
-    let service = this.subject;
-    let mockOptions = { locale: 'en' };
+    let clientSecret = 'client-secret';
+    let expected = {};
 
-    let confirmSetupIntent = sinon.stub(service, 'confirmSetupIntent').callsFake(function(options) {
-      assert.deepEqual(options, mockOptions, 'called with mock options');
-    });
+    let stub = sinon.stub(this.subject.instance, 'handleCardAction');
+    stub.returns(expected);
 
-    confirmSetupIntent(mockOptions);
-    confirmSetupIntent.restore();
+    let actual = this.subject.handleCardAction(clientSecret);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret));
+    assert.strictEqual(actual, expected);
   });
 
-  test('it throws an error if config.stripe.publishableKey is not set', function(assert) {
+  test('it proxies stripe.retrievePaymentIntent', function (assert) {
+    this.subject.configure();
+
+    let clientSecret = 'client-secret';
+    let expected = {};
+
+    let stub = sinon.stub(this.subject.instance, 'retrievePaymentIntent');
+    stub.returns(expected);
+
+    let actual = this.subject.retrievePaymentIntent(clientSecret);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmCardSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+    let options = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmCardSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmCardSetup(clientSecret, data, options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data, options));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmAuBecsDebitSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmAuBecsDebitSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmAuBecsDebitSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmBacsDebitSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmBacsDebitSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmBacsDebitSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmBancontactSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmBancontactSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmBancontactSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmIdealSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmIdealSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmIdealSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmSepaDebitSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmSepaDebitSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmSepaDebitSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmSofortSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let data = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmSofortSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmSofortSetup(clientSecret, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.retrieveSetupIntent', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+
+    let stub = sinon.stub(this.subject.instance, 'retrieveSetupIntent');
+    stub.returns(expected);
+
+    let actual = this.subject.retrieveSetupIntent(clientSecret);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.createPaymentMethod', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let paymentMethodData = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'createPaymentMethod');
+    stub.returns(expected);
+
+    let actual = this.subject.createPaymentMethod(paymentMethodData);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(paymentMethodData));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.paymentRequest', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let options = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'paymentRequest');
+    stub.returns(expected);
+
+    let actual = this.subject.paymentRequest(options);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(options));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.createToken', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let cardElement = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'createToken');
+    stub.returns(expected);
+
+    let actual = this.subject.createToken(cardElement, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(cardElement, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.createSource', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let element = { foo: 'bar' };
+    let sourceData = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'createSource');
+    stub.returns(expected);
+
+    let actual = this.subject.createSource(element, sourceData);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(element, sourceData));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.retrieveSource', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let source = { foo: 'bar' };
+
+    let stub = sinon.stub(this.subject.instance, 'retrieveSource');
+    stub.returns(expected);
+
+    let actual = this.subject.retrieveSource(source);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(source));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.handleCardPayment', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let element = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'handleCardPayment');
+    stub.returns(expected);
+
+    let actual = this.subject.handleCardPayment(clientSecret, element, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, element, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmPaymentIntent', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let element = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmPaymentIntent');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmPaymentIntent(clientSecret, element, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, element, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.handleCardSetup', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let element = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'handleCardSetup');
+    stub.returns(expected);
+
+    let actual = this.subject.handleCardSetup(clientSecret, element, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, element, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.confirmSetupIntent', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let element = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'confirmSetupIntent');
+    stub.returns(expected);
+
+    let actual = this.subject.confirmSetupIntent(clientSecret, element, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, element, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it proxies stripe.handleFpxPayment', function (assert) {
+    this.subject.configure();
+
+    let expected = {};
+    let clientSecret = 'client-secret';
+    let element = { foo: 'bar' };
+    let data = { baz: 'bat' };
+
+    let stub = sinon.stub(this.subject.instance, 'handleFpxPayment');
+    stub.returns(expected);
+
+    let actual = this.subject.handleFpxPayment(clientSecret, element, data);
+
+    assert.ok(stub.calledOnce);
+    assert.ok(stub.calledWith(clientSecret, element, data));
+    assert.strictEqual(actual, expected);
+  });
+
+  test('it throws an error if config.stripe.publishableKey is not set', function (assert) {
     assert.expectAssertion(() => {
-      this.owner.factoryFor('service:stripev3').create({
-        config: {
-          mock: true,
-          publishableKey: null,
-          stripeOptions: null,
-        }
-      });
+      this.subject._config = {
+        mock: true,
+        publishableKey: null,
+        stripeOptions: null,
+      };
+
+      this.subject.configure();
     }, /Missing Stripe key/);
   });
 
-  test('it does not throw when publishableKey is provided by load method', async function(assert) {
-    this.subject = this.owner.factoryFor('service:stripev3').create({
-      config: {
-        mock: true,
-        lazyLoad: true,
-        publishableKey: null,
-        stripeOptions: null,
-      }
-    });
+  test('it does not throw when publishableKey is provided by load method', async function (assert) {
+    this.subject._config = {
+      mock: true,
+      publishableKey: null,
+      stripeOptions: null,
+    };
 
     await this.subject.load('some-key');
-    assert.ok(this.subject.get('didConfigure'), 'should have configured')
+
+    assert.ok(this.subject.instance);
   });
 });


### PR DESCRIPTION
This  refactors the Stripe Service to native class syntax. In doing so, it also updates all the available proxied methods so that it matches the latest Stripe JS API.

Marked as a draft PR as I want to test in an actual application before merging.
