### PR TITLE
fix: load environment config

### DIFF
--- a/app/services/stripev3.js
+++ b/app/services/stripev3.js
@@ -1,1 +1,8 @@
-export { default } from '@adopted-ember-addons/ember-stripe-elements/services/stripev3';
+import Service from "@adopted-ember-addons/ember-stripe-elements/services/stripev3";
+import ENV from "../config/environment";
+
+const config = ENV["stripe"] || {};
+
+export default class StripeV3 extends Service {
+  config = config;
+}


### PR DESCRIPTION
Without this change you must use `.load(...)` with the key and options. Basically making the config options useless.