### PR TITLE
Fix StripeMock to work with the stripeEventUtils helper

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -12,8 +12,14 @@ class StripeMock {
       create() {
         return {
           mount() {},
-          on() {},
+          on(eventName, fn) {
+            this._eventListeners[eventName] = fn;
+          },
           unmount() {},
+          _eventListeners: {},
+          _emitEvent(eventName, options) {
+            this._eventListeners[eventName]?.(options);
+          },
         };
       }
     };


### PR DESCRIPTION
Hi,

Forgive me if I'm missing something obvious here but it seems like `StripeMock` is not fully complete such that it's able to work with the `stripeEventUtils` helper: https://github.com/adopted-ember-addons/ember-stripe-elements/blob/8a6d281d4bf1ad5f78299c0afa30b0776192e52e/addon-test-support/index.js#L93-L101.

When `StripeMock#elements` is invoked via a call to the service's `getActiveElements` method, the dummy element object that is returned has an `on` method that does nothing and is missing the `_emitEvent` method used by `stripeEventUtils`.

After adding this rudimentary event emitter to the dummy element object I can get tests working when using `stripeEventUtils`.