### PR TITLE
chore!: rename stripev3 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Features
 
 - Inject `<script src="https://js.stripe.com/v3/"></script>` into your application's `<body>`
 - Initialize `Stripe` with your publishable key
-- Inject a `stripev3` service into your controllers so you can use the functions usually available on the `stripe` object (see https://stripe.com/docs/stripe-js/reference#the-stripe-object):
+- Inject a `stripe` service into your controllers so you can use the functions usually available on the `stripe` object (see https://stripe.com/docs/stripe-js/reference#the-stripe-object):
   - `stripe.elements()`
   - `stripe.confirmCardPayment()`
   - `stripe.createToken()`
@@ -103,11 +103,11 @@ When enabled, a [mock Stripe object](https://github.com/adopted-ember-addons/emb
 When using the Stripe mock in tests you will likely need to override the mock's methods according to the needs of your test like so:
 
 ```js
-this.owner.lookup('service:stripev3').createToken = () => ({ token: { id: 'token' } });
+this.owner.lookup('service:stripe').createToken = () => ({ token: { id: 'token' } });
 ```
 ### Testing and Simulating User Input
 
-When a {{stripe-element}} is instantiated and in the DOM, the underlying `stripeElement` is available via the `stripev3` service. Calling `stripeService.getActiveElements()` will return an array of those native stripeElements.
+When a {{stripe-element}} is instantiated and in the DOM, the underlying `stripeElement` is available via the `stripe` service. Calling `stripeService.getActiveElements()` will return an array of those native stripeElements.
 
 This is primarily useful in testing.  Stripe renders an iframe which is mostly inaccessible in a test environment, making simulating user input impossible.
 
@@ -170,7 +170,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SubscriptionRoute extends Route {
-  @service('stripev3') stripe;
+  @service stripe;
 
   beforeModel() {
     return this.stripe.load();
@@ -202,7 +202,7 @@ Every component will:
 - Bubble the proper JavaScript events into actions
 - Mount Stripe's own `StripeElement` in a `<div role="mount-point">` on `didInsertElement`
 - Unmount on `willDestroyElement`
-- Provide access to the `stripev3` service
+- Provide access to the `stripe` service
 - Have the base CSS class name `.ember-stripe-element`
 - Have a CSS class for the specific element that matches the component's name, e.g. `<EmberStripeCard/>` has the class `.ember-stripe-card`
 - Yield to a block
@@ -342,7 +342,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from '@ember/object';
 
 export default class SubscriptionController extends Controller {
-  @service stripev3;
+  @service stripe;
 
   options = {
     hidePostalCode: true,

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -8,7 +8,7 @@ export default class StripeElement extends Component {
   @tracked type = null; // Set in components that extend from `stripe-element`
   @tracked _stripeError = null;
 
-  @service stripev3;
+  @service stripe;
 
   get autofocus() {
     return this.args.autofocus;
@@ -23,7 +23,7 @@ export default class StripeElement extends Component {
       return this.args._elements;
     }
 
-    return this.stripev3.elements();
+    return this.stripe.elements();
   }
 
   get stripeError() {
@@ -53,7 +53,7 @@ export default class StripeElement extends Component {
 
     // Make the element available to the component
     this.stripeElement = stripeElement;
-    this.stripev3.addStripeElement(stripeElement);
+    this.stripe.addStripeElement(stripeElement);
   }
 
   focusElement(element) {
@@ -117,7 +117,7 @@ export default class StripeElement extends Component {
 
   willDestroy() {
     this.stripeElement.unmount();
-    this.stripev3.removeStripeElement(this.stripeElement);
+    this.stripe.removeStripeElement(this.stripeElement);
     super.willDestroy(...arguments);
   }
 }

--- a/addon/components/stripe-elements.js
+++ b/addon/components/stripe-elements.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 export default class StripeElements extends Component {
-  @service('stripev3') stripe;
+  @service stripe;
 
   get options() {
     return this.args.options || {};

--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -79,7 +79,7 @@ export default class StripeService extends Service {
 
       if (!publishableKey) {
         throw new Error(
-          'stripev3: Missing Stripe key, please set `ENV.stripe.publishableKey` in config/environment.js'
+          'stripe: Missing Stripe key, please set `ENV.stripe.publishableKey` in config/environment.js'
         );
       }
 

--- a/app/services/stripe.js
+++ b/app/services/stripe.js
@@ -1,0 +1,1 @@
+export { default } from '@adopted-ember-addons/ember-stripe-elements/services/stripe';

--- a/app/services/stripev3.js
+++ b/app/services/stripev3.js
@@ -1,1 +1,0 @@
-export { default } from '@adopted-ember-addons/ember-stripe-elements/services/stripev3';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -23,7 +23,7 @@ let style = {
 };
 
 export default class Application extends Controller {
-  @service('stripev3') stripe;
+  @service stripe;
 
   @tracked token = null;
   @tracked cardOptions = null;

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
-  @service('stripev3') stripe;
+  @service stripe;
 
   beforeModel() {
     return this.stripe.load();

--- a/tests/integration/components/stripe-card-cvc-test.js
+++ b/tests/integration/components/stripe-card-cvc-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | stripe-card-cvc', function (hooks) {
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/integration/components/stripe-card-expiry-test.js
+++ b/tests/integration/components/stripe-card-expiry-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | stripe-card-expiry', function (hooks) {
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
 
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/integration/components/stripe-card-number-test.js
+++ b/tests/integration/components/stripe-card-number-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | stripe card number', function (hooks) {
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/integration/components/stripe-card-test.js
+++ b/tests/integration/components/stripe-card-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | stripe-card', function (hooks) {
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/integration/components/stripe-elements-test.js
+++ b/tests/integration/components/stripe-elements-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | stripe-elements', function (hooks) {
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/integration/components/stripe-postal-code-test.js
+++ b/tests/integration/components/stripe-postal-code-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | stripe-postal-code', function (hooks) {
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.stripe = this.owner.lookup('service:stripev3');
+    this.stripe = this.owner.lookup('service:stripe');
     this.stripe.configure();
   });
 

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -3,12 +3,12 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import StripeMock from '@adopted-ember-addons/ember-stripe-elements/test-support';
 
-module('Unit | Service | stripev3', function (hooks) {
+module('Unit | Service | stripe', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
     window.Stripe = StripeMock;
-    this.subject = this.owner.lookup('service:stripev3');
+    this.subject = this.owner.lookup('service:stripe');
   });
 
   test('it proxies stripe.elements', function (assert) {
@@ -629,7 +629,7 @@ module('Unit | Service | stripev3', function (hooks) {
         this.subject.configure();
       },
       new Error(
-        'stripev3: Missing Stripe key, please set `ENV.stripe.publishableKey` in config/environment.js'
+        'stripe: Missing Stripe key, please set `ENV.stripe.publishableKey` in config/environment.js'
       ),
       'Missing config.stripe.publishableKey should throw an error'
     );


### PR DESCRIPTION
If merged this would be a breaking change.

I've found it slightly annoying to have to remember that the service for Stripe is called `stripev3` instead of just `stripe`.