### PR TITLE
feat!: replace script tag with Stripe.js package, default to lazy load

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,36 @@ ENV.stripe = {
 };
 ```
 
+### Loading Stripe
+
+Stripe.js will not be loaded until you call the `load()` function on the service. It's best to call this function in a route's `beforeModel` hook.
+
+```js
+// subscription page route
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class SubscriptionRoute extends Route {
+  @service('stripev3') stripe;
+
+  beforeModel() {
+    return this.stripe.load();
+  }
+}
+```
+
+Note that the `load` function returns a `Promise`. By returning this promise you ensure that Stripe is fully loaded before the route procedes to the next `model` hook.
+
+You can also pass `publishableKey` and optional `stripeOptions` to the `load` function.
+
+```js
+this.stripe.load('pk_thisIsATestKey', {
+  locale: 'en',
+  stripeAccount: 'acct_24BFMpJ1svR5A89k',
+});
+```
+
 ### Mocking the Stripe API
 
 You can configure the Stripe API to be mocked instead of loaded from `@stripe/stripe-js`. This is useful for testing.
@@ -148,44 +178,6 @@ module('...', function (hooks) {
     stripeEventUtils.triggerComplete(stripeElement);
     ...
   });
-});
-```
-
-### Lazy loading
-
-You can configure Stripe.js to lazy load when you need it.
-
-```js
-ENV.stripe = {
-  lazyLoad: true,
-};
-```
-
-When enabled, Stripe.js will not be loaded until you call the `load()` function on the service. It's best to call this function in a route's `beforeModel` hook.
-
-```js
-// subscription page route
-
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-
-export default class SubscriptionRoute extends Route {
-  @service('stripev3') stripe;
-
-  beforeModel() {
-    return this.stripe.load();
-  }
-}
-```
-
-Note that the `load` function returns a `Promise`. By returning this promise you ensure that Stripe is fully loaded before the route procedes to the next `model` hook.
-
-You can also pass `publishableKey` and optional `stripeOptions` to the `load` function.
-
-```js
-this.stripe.load('pk_thisIsATestKey', {
-  locale: 'en',
-  stripeAccount: 'acct_24BFMpJ1svR5A89k',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you can spare some time in helping maintain this addon, please let us know in
 Features
 ------------------------------------------------------------------------------
 
-- Inject `<script src="https://js.stripe.com/v3/"></script>` into your application's `<body>`
+- Install `@stripe/stripe-js`
 - Initialize `Stripe` with your publishable key
 - Inject a `stripev3` service into your controllers so you can use the functions usually available on the `stripe` object (see https://stripe.com/docs/stripe-js/reference#the-stripe-object):
   - `stripe.elements()`
@@ -90,7 +90,7 @@ ENV.stripe = {
 
 ### Mocking the Stripe API
 
-You can configure the Stripe API to be mocked instead of loaded from `https://js.stripe.com/v3/`. This is useful for testing.
+You can configure the Stripe API to be mocked instead of loaded from `@stripe/stripe-js`. This is useful for testing.
 
 ```js
 ENV.stripe = {

--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -23,10 +23,6 @@ export default class StripeService extends Service {
     }
   }
 
-  get lazyLoad() {
-    return Boolean(this._config.lazyLoad);
-  }
-
   get mock() {
     return Boolean(this._config.mock);
   }

--- a/index.js
+++ b/index.js
@@ -3,15 +3,4 @@
 
 module.exports = {
   name: '@adopted-ember-addons/ember-stripe-elements',
-
-  contentFor(type, config) {
-    let stripeConfig = config.stripe || {};
-
-    var lazyLoad = stripeConfig.lazyLoad;
-    var mock = stripeConfig.mock;
-
-    if (type === 'body' && !lazyLoad && !mock) {
-      return '<script type="text/javascript" src="https://js.stripe.com/v3/"></script>';
-    }
-  },
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^4.5.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1"
   },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -25,7 +25,6 @@ module.exports = function (environment) {
   };
 
   ENV.stripe = {
-    lazyLoad: true,
     publishableKey: process.env.STRIPE_PUBLISHABLE_KEY || 'pk_thisIsATestKey',
     stripeOptions: {
       locale: 'en',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,6 +1670,11 @@
   resolved "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz"
   integrity sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==
 
+"@stripe/stripe-js@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-4.5.0.tgz#0beda9beefc05143ef6955d7bb7960064aecc53c"
+  integrity sha512-dMOzc58AOlsF20nYM/avzV8RFhO/vgYTY7ajLMH6mjlnZysnOHZxsECQvjEmL8Q/ukPwHkOnxSPW/QGCCnp7XA==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"


### PR DESCRIPTION
- Replace Stripe.js script tag injection with official package
- Default to lazy load behavior (requires `load()` call before usage)

Fixes #25